### PR TITLE
Hotfix/Eagerly load scores in feed

### DIFF
--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.includes(:user).order(played_at: :desc, id: :desc)
       serialized_scores = scores.map(&:serialize)
 
       response = {


### PR DESCRIPTION
Fixes: [#1](https://github.com/AACraiu/golfr_backend/issues/1)

**Changes**

Uses `includes` method instead of `all` method on the `Score` model in the `ScoresController.user_feed` function, switching from lazily loading to eagerly loading the scores feed and solving the n+1 queries problem. 

**Before**

<img width="942" alt="Screenshot 2022-10-11 at 10 56 34" src="https://user-images.githubusercontent.com/114063340/195036095-e46f66e6-3201-40cf-ad4a-ee60e766409b.png">

**After**

<img width="968" alt="Screenshot 2022-10-11 at 11 07 13" src="https://user-images.githubusercontent.com/114063340/195036149-696f66b2-3a6b-4f64-b6a9-b766c0bfa80b.png">

