### PR TITLE
Feature/Add limit of 25 scores in feed

### DIFF
--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.all.limit(25).order(played_at: :desc, id: :desc)
       serialized_scores = scores.map(&:serialize)
 
       response = {


### PR DESCRIPTION
Fixes: [#21](https://github.com/AACraiu/golfr_backend/issues/21)

**Changes**

The scores feed may have at most the 25 most recent scores.
The attached test creates 25 scores for a user as for today and checks they if they are retrieved in the scores feed accordingly.

**Before**

<img width="931" alt="Screenshot 2022-10-11 at 15 50 03" src="https://user-images.githubusercontent.com/114063340/195098062-89e1ff72-416b-420b-9386-82826e5d15e9.png">

**After**

<img width="1073" alt="Screenshot 2022-10-11 at 15 56 08" src="https://user-images.githubusercontent.com/114063340/195098164-48bd411c-867e-49fe-bc5b-b67c5b5bfe3a.png">
